### PR TITLE
Reduce duplicate query count for singular object relation

### DIFF
--- a/src/Admin/Form/Fields/Renderer/ObjectRelationRenderer.php
+++ b/src/Admin/Form/Fields/Renderer/ObjectRelationRenderer.php
@@ -74,25 +74,17 @@ class ObjectRelationRenderer implements RendererInterface
      */
     protected function getRelatedItemsElement()
     {
-        $items = [];
-        $values = $this->field->getValue();
-
-        if( $values )
-        {
-            $values = $values instanceof Collection ? $values : new Collection( [ $values ] );
-
-            foreach( $values as $value )
-            {
+        $items = $this->field->getValue()
+            ->map(function ($value) {
                 $relation = $value->related()->first();
 
-                if( $relation )
-                {
-                    $items[] = $this->buildRelationalItemElement( $relation );
+                if ($relation) {
+                    return $this->buildRelationalItemElement($relation);
                 }
-            }
-        }
+            })
+            ->toArray();
 
-        return Html::div( $items )->addClass( 'related' );
+        return Html::div($items)->addClass('related');
     }
 
     /**
@@ -187,7 +179,7 @@ class ObjectRelationRenderer implements RendererInterface
         } else {
             $options->addClass('interactive');
         }
-        
+
         return $options;
     }
 }


### PR DESCRIPTION
`$this->value = $this->isSingular() ? $relation->first() : $relation->get();`
If field is singular, and there is no relation set, $relation->first() returns null, causing `if( !$this->value )` to always fail. Not an issue if number of possible relations is small, but causes performance issues once the possible relations number grows.